### PR TITLE
New Laravel Passport Version 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "keywords": ["Laravel", "passport" ,"jwt" , "claim", "laravel-passport-claims"],
     "require": {
         "illuminate/support": "^9.0",
-        "laravel/passport": "^11.2"
+        "laravel/passport": "^10.3|^11.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "keywords": ["Laravel", "passport" ,"jwt" , "claim", "laravel-passport-claims"],
     "require": {
         "illuminate/support": "^9.0",
-        "laravel/passport": "^10.3"
+        "laravel/passport": "^11.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",


### PR DESCRIPTION
There seem to be no breaking changes related to this package. So allowing version 11 of passport seems to suffice.