### PR TITLE
Support multiple values on middleware

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,11 +115,19 @@ Route::middleware(['client', 'claim:my-claim'])->get('my-protected-route', funct
 });
 ```
 
-You can also check if the claim matches a specific value.
+You can check if the claim matches a specific value.
 
  ```php
  Route::middleware(['client', 'claim:my-claim,foobar'])->get('my-protected-route', function () {
      return 'protected by claim with foobar as its value';
+ });
+ ```
+ 
+You can also check if the claim matches a specific value from multiple values, you just need to add the values ​​separated with `|`.
+
+ ```php
+ Route::middleware(['client', 'claim:my-claim,foo|bar'])->get('my-protected-route', function () {
+     return 'protected by claim with foo or bar as its value';
  });
  ```
 

--- a/src/Http/Middleware/CheckForClaim.php
+++ b/src/Http/Middleware/CheckForClaim.php
@@ -39,7 +39,7 @@ class CheckForClaim
                 return $next($request);
             }
 
-            if ($jwt->claims()->get($claim) === $value) {
+            if (in_array($jwt->claims()->get($claim), explode('|', (string) $value))) {
                 return $next($request);
             }
 

--- a/src/Http/Middleware/CheckForClaim.php
+++ b/src/Http/Middleware/CheckForClaim.php
@@ -18,7 +18,7 @@ class CheckForClaim
      * @return mixed
      * @throws AuthenticationException
      */
-    public function handle($request, Closure $next, $claim, $value = null)
+    public function handle($request, Closure $next, $claim, $values = null)
     {
         /* check for presence of token */
         if ( ! ($token = $request->bearerToken())) {
@@ -35,12 +35,16 @@ class CheckForClaim
         /* check if we want to check both claim and value */
         if ($jwt->claims()->has($claim)) {
 
-            if ($value === null) {
+            if ($values === null) {
                 return $next($request);
             }
 
-            if (in_array($jwt->claims()->get($claim), explode('|', (string) $value))) {
-                return $next($request);
+            $claimValue = $jwt->claims()->get($claim);
+
+            foreach (explode('|', (string) $values) as $value) {
+                if ($claimValue == $value) {
+                    return $next($request);
+                }
             }
 
         }


### PR DESCRIPTION
 ```php
 Route::middleware(['client', 'claim:my-claim,foo|bar'])->get('my-protected-route', function () {
     return 'protected by claim with foo or bar as its value';
 });
 ```
Closes #26