### PR TITLE
Method `getToken` for get claims from anyplace

### DIFF
--- a/tests/CheckClaimMiddlewareTest.php
+++ b/tests/CheckClaimMiddlewareTest.php
@@ -19,6 +19,7 @@ class CheckClaimMiddlewareTest extends TestCase
 {
     protected function tearDown(): void
     {
+        CheckForClaim::setToken();
         m::close();
     }
 


### PR DESCRIPTION
Closes #24
```php
$jwt = CheckForClaim::getToken();
$claimValue = $jwt?->claims()->get('MyClaim')
```
Also, this avoids parsing same token on every claim, example
```php
Route::middleware(['client', 'claim:my-claim-one,foo', 'claim:my-claim-two,bar'])->get('my-route', function () {
    return 'protected by claim with foo and bar as its value';
});
```
On `my-claim-one` it parse the token, on `my-claim-two` it gets the already parsed token