### PR TITLE
allow for customization of the builder class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^7.0|^8.0",
         "phpseclib/phpseclib": "^3.0",
-        "phpseclib/phpseclib2_compat": "^1.0"
+        "phpseclib/phpseclib2_compat": "^1.0",
+        "nunomaduro/collision": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/passport-claims.php
+++ b/config/passport-claims.php
@@ -13,5 +13,17 @@ return [
     */
     'claims' => [
         // App\Claims\CustomClaim::class
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT Custom Builder
+    |--------------------------------------------------------------------------
+    |
+    | Here you can change which class implements the convertToJWT method.
+    | The class requires method convertToJWT() : Token to return a custom
+    | token builder for the pipeline. It must be a private function.
+    |
+    */
+    'builder' => \CorBosman\Passport\AccessToken::class
 ];

--- a/src/AccessTokenRepository.php
+++ b/src/AccessTokenRepository.php
@@ -2,6 +2,7 @@
 
 namespace CorBosman\Passport;
 
+use Laravel\Passport\Passport;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use Laravel\Passport\Bridge\AccessTokenRepository as PassportAccessTokenRepository;
 
@@ -12,6 +13,7 @@ class AccessTokenRepository extends PassportAccessTokenRepository
      */
     public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
     {
-        return new AccessToken($userIdentifier, $scopes, $clientEntity);
+        \Laravel\Passport\Passport::useAccessTokenEntity(config('passport-claims.builder', AccessToken::class));
+        return new \Laravel\Passport\Passport::$accessTokenEntity($userIdentifier, $scopes, $clientEntity);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,7 +12,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function boot()
     {
         if (method_exists(Passport::class, 'useAccessTokenEntity')) {
-            Passport::useAccessTokenEntity(AccessToken::class);
+            // I'm actually a little confused about this I may need a better way to test this
+            Passport::useAccessTokenEntity(config('passport-claims.builder', AccessToken::class));
         } else {
             $this->app->bind(PassportAccessTokenRepository::class, AccessTokenRepository::class);
         }
@@ -34,5 +35,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         ]);
 
         $this->commands([ClaimGenerator::class]);
+    }
+
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/passport-claims.php', 'passport-claims');
     }
 }

--- a/tests/Builders/CustomAccessTokenBuilderAddsIssuer.php
+++ b/tests/Builders/CustomAccessTokenBuilderAddsIssuer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace CorBosman\Passport\Tests\Builders;
+
+use CorBosman\Passport\ClaimsFormatter;
+use CorBosman\Passport\Traits\ClaimTrait;
+use Illuminate\Pipeline\Pipeline;
+use Laravel\Passport\Bridge\AccessToken as PassportAccessToken;
+use Lcobucci\JWT\Token;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
+use \DateTimeImmutable;
+
+class CustomAccessTokenBuilderAddsIssuer extends PassportAccessToken implements AccessTokenEntityInterface
+{
+    use AccessTokenTrait, ClaimTrait;
+
+    /**
+     * Generate a JWT from the access token
+     *
+     * @return Token
+     */
+    private function convertToJWT() : Token
+    {
+        $this->initJwtConfiguration();
+
+        $jwt = $this->jwtConfiguration->builder(ClaimsFormatter::formatters())
+            ->permittedFor($this->getClient()->getIdentifier())
+            ->identifiedBy($this->getIdentifier())
+            ->issuedAt(new DateTimeImmutable())
+            ->canOnlyBeUsedAfter(new DateTimeImmutable())
+            ->expiresAt($this->getExpiryDateTime())
+            ->relatedTo((string) $this->getUserIdentifier())
+            ->withClaim('scopes', $this->getScopes())
+            ->issuedBy('CustomTokenIssuer');
+
+        return collect(app(Pipeline::class)
+            ->send($this)
+            ->through(config('passport-claims.claims', []))
+            ->thenReturn()
+            ->claims())
+            ->reduce(fn($jwt, $value, $key) => $jwt->withClaim($key, $value), $jwt)
+            ->getToken($this->jwtConfiguration->signer(), $this->jwtConfiguration->signingKey());
+    }
+}

--- a/tests/CustomBuilderClassTest.php
+++ b/tests/CustomBuilderClassTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace CorBosman\Passport\Tests;
+
+use CorBosman\Passport\ServiceProvider;
+use CorBosman\Passport\Tests\Builders\CustomAccessTokenBuilderAddsIssuer;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Mockery as m;
+use Lcobucci\JWT\Token\Parser;
+use phpseclib\Crypt\RSA;
+use Carbon\CarbonImmutable;
+use Orchestra\Testbench\TestCase;
+use League\OAuth2\Server\CryptKey;
+use Laravel\Passport\Bridge\Client;
+use Laravel\Passport\TokenRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use CorBosman\Passport\Tests\Claims\MyClaim;
+use CorBosman\Passport\AccessTokenRepository;
+use CorBosman\Passport\Tests\Claims\AnotherClaim;
+
+class CustomBuilderClassTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function test_can_add_custom_builder()
+    {
+        /* set custom token builder */
+        app('config')->set('passport-claims.builder', CustomAccessTokenBuilderAddsIssuer::class);
+
+        /* set up the environment */
+        $repository = new AccessTokenRepository(m::mock(TokenRepository::class), m::mock(Dispatcher::class));
+        $client = new Client('client-id', 'name', 'redirect');
+        $scopes = [];
+        $userIdentifier = 1;
+        $keys = (new RSA())->createKey(2048);
+
+        /* create the laravel token */
+        $token = $repository->getNewToken($client, $scopes, $userIdentifier);
+        $token->setPrivateKey(new CryptKey($keys['privatekey']));
+        $token->setExpiryDateTime(CarbonImmutable::now()->addHour());
+        $token->setIdentifier('test');
+
+        /* convert the token to a JWT and parse the JWT back to a Token */
+        $jwt = (new Parser(new JoseEncoder))->parse($token->__toString());
+
+        /* assert our claims were set on the token */
+        $this->assertEquals(true, $jwt->hasBeenIssuedBy('CustomTokenIssuer'));
+    }
+}
+


### PR DESCRIPTION
This isn't tested in a real laravel app yet but I did take a stab at it. I will test further in my app soon.

Note: I couldn't quite figure out what the difference between the ServiceProvider setting the `AccessToken` class was vs the AccessTokenRepository. It appears the Repository is needed for the unit test but I wasn't convinced based on the way the SP was written that it didn't need to be set in both places. Any ideas on this would be helpful. 