### PR TITLE
Add Laravel 11 support to v7.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel-passport-claims"
     ],
     "require": {
-        "illuminate/support": "12.*",
+        "illuminate/support": "^11.0|^12.0",
         "laravel/passport": "^11.2|^12.0",
         "nesbot/carbon": "^3"
     },


### PR DESCRIPTION
Adjusts `illuminate/support` so Laravel 11 and Laravel 12 are formally supported as part of v7.0.0.

May I also request for v7.0.0 to be tagged? Unless of course there's something that needs to be tackled before that can happen.

Thanks!